### PR TITLE
Fix encryption key generation

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -22,7 +22,7 @@ export default class Keys {
         })
     }
     async createEncryptionKey() {
-        this.encryptionKey = crypto.subtle.generateKey({ name: "AES-CTR", length: 256 }, true, ["encrypt", "decrypt"])
+        this.encryptionKey = await crypto.subtle.generateKey({ name: "AES-CTR", length: 256 }, true, ["encrypt", "decrypt"])
         return this.encryptionKey
     }
     buf2hex(buffer) {


### PR DESCRIPTION
## Summary
- await AES key generation so encryption key is stored as `CryptoKey`

## Testing
- `npm test` *(fails: SyntaxError about missing export)*

------
https://chatgpt.com/codex/tasks/task_e_684597c2e5988327aa3cacca50ea56c3